### PR TITLE
Fixed error where reference app errors out

### DIFF
--- a/src/app-search/AppSearchDriver.js
+++ b/src/app-search/AppSearchDriver.js
@@ -160,7 +160,7 @@ export default class AppSearchDriver {
         this._setState({
           current,
           error: "",
-          facets: resultList.info.facets,
+          facets: resultList.info.facets || {},
           filters,
           requestId: resultList.info.meta.request_id,
           results: resultList.results,

--- a/src/app-search/AppSearchDriver.test.js
+++ b/src/app-search/AppSearchDriver.test.js
@@ -15,6 +15,18 @@ const resultList = {
   results: [{}, {}]
 };
 
+const resultListWithoutFacets = {
+  info: {
+    meta: {
+      page: {
+        total_results: 1000
+      },
+      request_id: "12345"
+    }
+  },
+  results: [{}, {}]
+};
+
 const params = {
   engineName: "some-engine",
   hostIdentifier: "host-XXXX",
@@ -29,6 +41,11 @@ const mockClient = {
 
 beforeAll(() => {
   SwiftypeAppSearch.createClient.mockReturnValue(mockClient);
+});
+
+beforeEach(() => {
+  mockClient.search = jest.fn().mockReturnValue({ then: cb => cb(resultList) });
+  mockClient.click = jest.fn().mockReturnValue({ then: () => {} });
 });
 
 it("can be initialized", () => {
@@ -59,6 +76,30 @@ it("will use initial state if provided", () => {
   expect(stateAfterCreation).toEqual({
     ...DEFAULT_STATE,
     ...initialState
+  });
+});
+
+it("will default facets to {} in state if facets is missing from the response", () => {
+  const initialState = {
+    searchTerm: "test"
+  };
+
+  mockClient.search = jest
+    .fn()
+    .mockReturnValue({ then: cb => cb(resultListWithoutFacets) });
+
+  const driver = new AppSearchDriver({
+    ...params,
+    initialState
+  });
+  const stateAfterCreation = driver.getState();
+
+  expect(stateAfterCreation).toEqual({
+    ...DEFAULT_STATE,
+    ...initialState,
+    requestId: "12345",
+    results: [{}, {}],
+    totalResults: 1000
   });
 });
 

--- a/src/config/config-helper.js
+++ b/src/config/config-helper.js
@@ -131,11 +131,11 @@ export function buildSearchOptionsFromConfig() {
     return acc;
   }, undefined);
 
-  return {
-    facets,
-    result_fields: resultFields,
-    search_fields: searchFields
-  };
+  const searchOptions = {};
+  if (facets) searchOptions.facets = facets;
+  searchOptions.result_fields = resultFields;
+  searchOptions.search_fields = searchFields;
+  return searchOptions;
 }
 
 export function buildSortOptionsFromConfig() {


### PR DESCRIPTION
Reference App errored out when no facets were provided. The
state was being rewritten to undefined, but it needs to default
to {}