### PR TITLE
Added logic to add title and url fields

### DIFF
--- a/src/config/config-helper.js
+++ b/src/config/config-helper.js
@@ -122,6 +122,28 @@ export function buildSearchOptionsFromConfig() {
     return acc;
   }, undefined);
 
+  // We can't use url or title fields unless they're actually
+  // in the reuslts.
+  if (config.urlField) {
+    resultFields[config.urlField] = {
+      raw: {},
+      snippet: {
+        size: 100,
+        fallback: true
+      }
+    };
+  }
+
+  if (config.titleField) {
+    resultFields[config.titleField] = {
+      raw: {},
+      snippet: {
+        size: 100,
+        fallback: true
+      }
+    };
+  }
+
   const facets = (config.facets || []).reduce((acc, n) => {
     acc = acc || {};
     acc[n] = {


### PR DESCRIPTION
If title and url fields are not included in the `fields`
config, but ARE specified as the titleField or urlField config,
then they will not work. I added logic to make sure that if they
are used for either of those, that they are added to the results.