### PR TITLE
Removed use of raw values in results

### DIFF
--- a/src/components/Result.js
+++ b/src/components/Result.js
@@ -5,21 +5,23 @@ function Result({ fields, onClickLink, title, url }) {
   return (
     <li className="result">
       <div className="result__header">
-        {!url && (
-          <span
-            className="result__title"
-            dangerouslySetInnerHTML={{ __html: title }}
-          />
-        )}
-        {url && (
-          <a
-            className="result__title"
-            dangerouslySetInnerHTML={{ __html: title }}
-            href={url}
-            onClick={onClickLink}
-            target="_blank"
-          />
-        )}
+        {title &&
+          !url && (
+            <span
+              className="result__title"
+              dangerouslySetInnerHTML={{ __html: title }}
+            />
+          )}
+        {title &&
+          url && (
+            <a
+              className="result__title"
+              dangerouslySetInnerHTML={{ __html: title }}
+              href={url}
+              onClick={onClickLink}
+              target="_blank"
+            />
+          )}
       </div>
       <div className="result__body">
         <ul className="result__details">
@@ -40,7 +42,7 @@ function Result({ fields, onClickLink, title, url }) {
 
 Result.propTypes = {
   fields: PropTypes.object.isRequired,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   url: PropTypes.string
 };
 

--- a/src/components/Result.test.js
+++ b/src/components/Result.test.js
@@ -3,8 +3,7 @@ import Result from "./Result";
 import { shallow } from "enzyme";
 
 const requiredProps = {
-  fields: { field: "value" },
-  title: "Title"
+  fields: { field: "value" }
 };
 
 it("renders correctly when there is a URL", () => {
@@ -14,7 +13,19 @@ it("renders correctly when there is a URL", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-it("renders correctly when there is not a URL", () => {
+it("renders correctly when there is not a URL or title", () => {
   const wrapper = shallow(<Result {...requiredProps} />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("renders correctly when there is a title", () => {
+  const wrapper = shallow(<Result {...requiredProps} title="Title" />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("renders correctly when there is a title and url", () => {
+  const wrapper = shallow(
+    <Result {...requiredProps} title="Title" url="http://www.example.com" />
+  );
   expect(wrapper).toMatchSnapshot();
 });

--- a/src/components/__snapshots__/Result.test.js.snap
+++ b/src/components/__snapshots__/Result.test.js.snap
@@ -6,6 +6,87 @@ exports[`renders correctly when there is a URL 1`] = `
 >
   <div
     className="result__header"
+  />
+  <div
+    className="result__body"
+  >
+    <ul
+      className="result__details"
+    >
+      <li
+        key="field"
+      >
+        <span
+          className="result__key"
+        >
+          field
+        </span>
+         
+        <span
+          className="result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "value",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+</li>
+`;
+
+exports[`renders correctly when there is a title 1`] = `
+<li
+  className="result"
+>
+  <div
+    className="result__header"
+  >
+    <span
+      className="result__title"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Title",
+        }
+      }
+    />
+  </div>
+  <div
+    className="result__body"
+  >
+    <ul
+      className="result__details"
+    >
+      <li
+        key="field"
+      >
+        <span
+          className="result__key"
+        >
+          field
+        </span>
+         
+        <span
+          className="result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "value",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+</li>
+`;
+
+exports[`renders correctly when there is a title and url 1`] = `
+<li
+  className="result"
+>
+  <div
+    className="result__header"
   >
     <a
       className="result__title"
@@ -47,22 +128,13 @@ exports[`renders correctly when there is a URL 1`] = `
 </li>
 `;
 
-exports[`renders correctly when there is not a URL 1`] = `
+exports[`renders correctly when there is not a URL or title 1`] = `
 <li
   className="result"
 >
   <div
     className="result__header"
-  >
-    <span
-      className="result__title"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Title",
-        }
-      }
-    />
-  </div>
+  />
   <div
     className="result__body"
   >

--- a/src/config/config-helper.js
+++ b/src/config/config-helper.js
@@ -53,11 +53,7 @@ export function getUrlFieldTemplate() {
 export function getResultTitle(result) {
   const titleField = getTitleField();
 
-  return (
-    result.getSnippet(titleField) ||
-    result.getRaw(titleField) ||
-    result.getRaw("id") // As a last resort, just show ID if nothing else
-  );
+  return result.getSnippet(titleField);
 }
 
 export function getResultUrl(result) {

--- a/src/containers/Results.js
+++ b/src/containers/Results.js
@@ -19,7 +19,7 @@ function capitalizeFirstLetter(string) {
 */
 function formatResultFields(result) {
   return Object.keys(result.data).reduce((acc, n) => {
-    let value = result.getSnippet(n) || result.getRaw(n);
+    let value = result.getSnippet(n);
     value = Array.isArray(value) ? value.join(", ") : value;
     acc[`${capitalizeFirstLetter(n)}`] = value;
     return acc;


### PR DESCRIPTION
- Removed any logic that would pass a "raw" value in a Result component as a `title` or `field value`, since they are rendered unsafely.
- Made `title` optional for Results. Since we *were* falling back to using an id, and id only ever comes back as a raw, unescaped value, we can't use it for the title as a fallback, as we previously were.